### PR TITLE
Create Variable seeder for database

### DIFF
--- a/tests/zephyr_db/test_seeding.py
+++ b/tests/zephyr_db/test_seeding.py
@@ -64,3 +64,4 @@ def test_seed_variables(db_session):
     var = db_session.query(Variable).filter(Variable.name == 'average wind speed').first()
 
     assert var.name == wind_speed_var.name
+    assert var.unit_id == unit.id

--- a/zephyr_db/seed/utils.py
+++ b/zephyr_db/seed/utils.py
@@ -27,6 +27,7 @@ def _seed_data(session, model, data: list[dict]) -> None:
         data: List of dictionaries containing record data.
     """
     existing_names = {r.name for r in session.query(model.name)}
+    # Using name as duplication protection
     new_records = [model(**row) for row in data if row['name'] not in existing_names]
     if new_records:
         session.add_all(new_records)

--- a/zephyr_db/seed/variables.py
+++ b/zephyr_db/seed/variables.py
@@ -5,32 +5,29 @@ from zephyr_db.models import Variable
 
 from .utils import seed_table
 
-VARIABLES = [{'name': 'wind speed', 'unit': 'wind speed'},
-             {'name': 'wind direction', 'unit': 'wind dir'}]
-
-
+VARIABLES = [
+    {'name': 'wind speed', 'unit': 'wind speed'},
+    {'name': 'wind direction', 'unit': 'wind dir'},
+]
 
 
 def seed_variables() -> None:
     """Populate database with measurement variables."""
-    units_df = pl.read_database("SELECT * FROM units", engine)
+    units_df = pl.read_database('SELECT * FROM units', engine)
 
     variables = []
 
     for var in VARIABLES:
-
-        if "unit" not in var:
+        if 'unit' not in var:
             continue
 
-
-        unit_id = units_df.filter(pl.col("name") == var["unit"]).select("id").item()
-
+        unit_id = units_df.filter(pl.col('name') == var['unit']).select('id').item()
 
         variables.append(
             {
-                "name": var['name'],
-                "unit": var['unit'],
-                "unit_id": unit_id,
+                'name': var['name'],
+                'unit': var['unit'],
+                'unit_id': unit_id,
             }
         )
     seed_table(Variable, variables)

--- a/zephyr_db/seed/variables.py
+++ b/zephyr_db/seed/variables.py
@@ -1,10 +1,36 @@
+import polars as pl
+
+from zephyr_db import engine
 from zephyr_db.models import Variable
 
 from .utils import seed_table
 
-VARIABLES = [{'name': 'wind speed', 'unit': 'wind speed'}]
+VARIABLES = [{'name': 'wind speed', 'unit': 'wind speed'},
+             {'name': 'wind direction', 'unit': 'wind dir'}]
+
+
 
 
 def seed_variables() -> None:
     """Populate database with measurement variables."""
-    seed_table(Variable, VARIABLES)
+    units_df = pl.read_database("SELECT * FROM units", engine)
+
+    variables = []
+
+    for var in VARIABLES:
+
+        if "unit" not in var:
+            continue
+
+
+        unit_id = units_df.filter(pl.col("name") == var["unit"]).select("id").item()
+
+
+        variables.append(
+            {
+                "name": var['name'],
+                "unit": var['unit'],
+                "unit_id": unit_id,
+            }
+        )
+    seed_table(Variable, variables)


### PR DESCRIPTION
Added seed_variables() function to variables.py

This function: 
- gets all of the units in the database (DB has to have units seeded first)
- associates units with each variable
- if the variable name isnt already in the database, adds the new variable


Testing: 
- added test_seed_variables() which verifies a variable is seeded properly to the database. 

closes #14 